### PR TITLE
Update nginx.conf to disable absolute_redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,6 +41,7 @@ http {
         listen       8080 default_server;
         server_name  _;
         port_in_redirect        off;
+        absolute_redirect       off;
         proxy_http_version      1.1;
         proxy_buffering         on;
 


### PR DESCRIPTION
To my knowledge, this is the primary nginx example that fly offers so having just run into this extremely confusing issue when recently migrating my site to fly, I figured this might save someone in the future.

It won't actually do anything with current config but I can imagine someone cloning the config and then modifying it to serve static files instead.

Below is the explainer message included in the body of the commit

```
This is one of those commits that features hours of blood, sweat and
tears just to generate one line of code.

While it has no use currently in this file, it will save anyone who
takes this configuration and attempts to use the try_files directive.

Everything will be perfectly fine until one day, a lone iframe on your
site breaks and nothing makes sense anymore. You'll trawl through acres
of searches, none of which shed any light on this niche issue.

There are a few prerequisites to see this in action:
  * A try_files directive
  * A URL that redirects (301) ie /cool -> /cool/
  * Probably a CSP header but maybe an HSTS header will cause this too

There are a number of headers that fly provides such as
X-Forwarded-Proto among others.

Normally, this would be passed along to an application via proxy_pass
and then the application would render links with https as the scheme.

The trouble here is that try_files appears to have no such concern with
X-Forwarded-Proto or anything like that.

It still generates a Location header however, and try as you might, it
will always contain http as the scheme like so:

Location: http://example.org

This being because it's using the scheme of the actual nginx instance
itself, and with SSL termination done by fly, we aren't inside of an
actual ssl block. If we were, I'm sure this would be no problem.

Now, normally this would be fine. In fact, I imagine that you would get
a three layer redirect like so:

  * https://example.org -> http://example.org/ -> https://example.org/

It isn't hugely pretty but it works. In my case however, I have a CSP
header which means we end up with something like this:

Header: "frame-src 'self'"

  * https://utf9k.net -> http://utf9k.net -> wah, violated the CSP
    header because now we don't match self anymore

EDIT: To be clear, what's going on here is that the iframe I have,
is making a request from /blah to /blah/ and the server is responding
as expected but the Location header in the response has an http scheme.
This triggers my browser to then try to access the correct request path
but with a downgraded scheme (http) and that means the CSP header is
violated, killing the iframe before it renders content.

The above is actually only true for Content Security Policy Level 2. CSP Level
3 will be treating http and https as both matching self but even so,
we should try to avoid mixed requests where possible.

Regardless, even if we didn't run into the CSP header (or you don't have
one), you would still end up doing three round trips regardless which
can be avoided by simply inheriting the preferred scheme from the
current page.

I would have preferred some way to simply "force" or override the scheme
internally to always prefer https but I'm not sure that there is
anything like that? If so, let me know!
```